### PR TITLE
fix(style): get rid of unnecessary scrollbars

### DIFF
--- a/src/pages/c/[id]/index.tsx
+++ b/src/pages/c/[id]/index.tsx
@@ -34,7 +34,7 @@ const CardPage: NextPage<{ id: string }> = ({ id }) => {
   if (cardLoading)
     return (
       <BasePage>
-        <main className="flex min-h-screen items-center justify-center bg-base-100">
+        <main className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-base-100">
           <Loader />
         </main>
       </BasePage>
@@ -43,7 +43,7 @@ const CardPage: NextPage<{ id: string }> = ({ id }) => {
   if (cardError || !cardData)
     return (
       <BasePage>
-        <main className="flex min-h-screen items-center justify-center bg-base-100">
+        <main className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-base-100">
           <article className="prose">
             <h2>Error loading card</h2>
             <p>Try again later :(</p>
@@ -107,7 +107,7 @@ const CardPage: NextPage<{ id: string }> = ({ id }) => {
 
   return (
     <BasePage>
-      <div className="hero flex min-h-screen flex-col items-center bg-base-100">
+      <div className="hero flex min-h-[calc(100vh-64px)] flex-col items-center bg-base-100">
         <div className="card mb-12 mt-20 w-full max-w-sm shrink-0  p-6 shadow-2xl">
           <CardInfo />
         </div>

--- a/src/pages/c/[id]/sign.tsx
+++ b/src/pages/c/[id]/sign.tsx
@@ -48,7 +48,7 @@ const CardPage: NextPage<{ id: string }> = ({ id }) => {
   if (cardLoading)
     return (
       <BasePage>
-        <main className="flex min-h-screen items-center justify-center bg-base-100">
+        <main className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-base-100">
           <Loader />
         </main>
       </BasePage>
@@ -57,7 +57,7 @@ const CardPage: NextPage<{ id: string }> = ({ id }) => {
   if (cardError || !data)
     return (
       <BasePage>
-        <main className="flex min-h-screen items-center justify-center bg-base-100">
+        <main className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-base-100">
           <article className="prose">
             <h2>Error loading card</h2>
             <p>Try again later :(</p>
@@ -129,7 +129,7 @@ const CardPage: NextPage<{ id: string }> = ({ id }) => {
 
   return (
     <BasePage>
-      <div className="hero flex min-h-screen flex-col items-center bg-base-100">
+      <div className="hero flex min-h-[calc(100vh-64px)] flex-col items-center bg-base-100">
         <div className="card mb-12 mt-20 w-full max-w-sm shrink-0  p-6 shadow-2xl">
           <CardInfo />
         </div>

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -24,7 +24,7 @@ export default function CreateCard() {
       <Meta title="Create a card | bday.quest (beta)" />
 
       <Navbar />
-      <div className="hero min-h-screen bg-base-200">
+      <div className="hero min-h-[calc(100vh-64px)] bg-base-200">
         <div className="card w-full max-w-sm shrink-0 bg-base-100 shadow-2xl">
           <form
             className="card-body"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,7 +33,7 @@ export default function Home() {
       <Meta title="bday.quest (beta)" />
 
       <Navbar />
-      <div className="hero min-h-screen bg-base-200">
+      <div className="hero min-h-[calc(100vh-64px)] bg-base-200">
         <div className="hero-content text-center">
           <div className="max-w-md">
             <h1 className="text-5xl font-bold">bday.quest</h1>

--- a/src/pages/manage/[id].tsx
+++ b/src/pages/manage/[id].tsx
@@ -38,7 +38,7 @@ const ManageCard: NextPage<{ id: string }> = ({ id }) => {
   if (cardLoading)
     return (
       <BasePage>
-        <main className="flex min-h-screen items-center justify-center bg-base-100">
+        <main className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-base-100">
           <Loader />
         </main>
       </BasePage>
@@ -48,7 +48,7 @@ const ManageCard: NextPage<{ id: string }> = ({ id }) => {
     toast.error(cardError?.message ?? "");
     return (
       <BasePage>
-        <main className="flex min-h-screen items-center justify-center bg-base-100">
+        <main className="flex min-h-[calc(100vh-64px)] items-center justify-center bg-base-100">
           <article className="prose">
             <h2>Error loading mangement settings</h2>
             <p>{cardError?.message ?? ""}</p>
@@ -89,7 +89,7 @@ const ManageCard: NextPage<{ id: string }> = ({ id }) => {
 
   return (
     <BasePage>
-      <div className="hero flex min-h-screen items-center justify-center  bg-base-200">
+      <div className="hero flex min-h-[calc(100vh-64px)] items-center justify-center  bg-base-200">
         <div className="flex">
           <div className="card w-full max-w-sm shrink-0 bg-base-100 shadow-2xl">
             <form className="card-body" onSubmit={handleSubmit(onSubmit)}>

--- a/src/pages/manage/index.tsx
+++ b/src/pages/manage/index.tsx
@@ -122,7 +122,7 @@ export default function ManageCards() {
       <Meta title="Manage | bday.quest (beta)" />
 
       <Navbar />
-      <div className="hero flex min-h-screen flex-col items-center bg-base-100">
+      <div className="hero flex min-h-[calc(100vh-64px)] flex-col items-center bg-base-100">
         <Cards />
       </div>
     </>


### PR DESCRIPTION
Instead of using min-h-screen, it now uses min-h-[calc(100vh-64px)]. 64px is the height of the taskbar. So now there won't be a very unnecessary scrollbar on the side.

Before:
![before](https://github.com/astridlol/bday.quest/assets/107053109/217b8fcf-adb2-4fb7-ac3f-5d34b79bd89f)

After:
![after](https://github.com/astridlol/bday.quest/assets/107053109/02f65312-ea78-4991-a4af-1b9eb1d7b0f5)
